### PR TITLE
[BUGFIX] A path for the shim so it actually loads

### DIFF
--- a/src/main/resources/webjars-requirejs.js
+++ b/src/main/resources/webjars-requirejs.js
@@ -1,7 +1,6 @@
 /*global requirejs */
 
 requirejs.config({
-    shim: {
-        'restangular': [ 'webjars!angular.js', 'webjars!lodash.js' ]
-    }
+    paths: { 'restangular': webjars.path('restangular', 'restangular') },
+    shim: { 'restangular': [ 'webjars!angular.js', 'webjars!lodash.js' ] }
 });


### PR DESCRIPTION
Problem: The shim had no paths so require loaded the deps, but not the
actual restangular sources.

**This needs a smallish review** as I'm new to RequireJS, but it should fit the library.
